### PR TITLE
fix: replace deprecated onerror with addEventListener

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -44,10 +44,10 @@
         console.log('[typst-live] - Disconnected')
       });
 
-      ws.onerror = (_) => {
+      ws.addEventListener('error', (_) => {
         connected = false;
         console.log('[typst-live] - Connection error')
-      };
+      });
     }
 
     ensureConnection();


### PR DESCRIPTION
Sorry about that, somehow missed this.