### PR TITLE
Remove `./` from instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ nix run github:ItsEthra/typst-live
 ### 1. With auto recompilation
 * Launch `typst-live` from your terminal:
 ```
-$ ./typst-live <file.typ>
+$ typst-live <file.typ>
 Server is listening on http://127.0.0.1:5599/
 ```
 * Go to `http://127.0.0.1:5599/` in your browser.


### PR DESCRIPTION
Hi, this PR removes the extra `./` from the Usage section of the README, since if the user installs the package from cargo, then the executable would not be in their working directory.