### PR TITLE
Bugfix/macos hot reload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 
 *.typ
 *.pdf
+
+.idea

--- a/src/index.html
+++ b/src/index.html
@@ -20,7 +20,16 @@
       }
 
       console.log("[typst-live] Got refresh message, updating pdf");
-      document.getElementById("target").src += ""
+      const target = document.getElementById("target");
+      const url = new URL(target.src, location.href);
+      url.searchParams.set("t", Date.now().toString());
+      const nextSrc = url.toString();
+
+      // Safari/WebKit can keep showing a cached PDF even when the iframe src changes.
+      // Replacing the iframe forces the embedded PDF viewer to fully reinitialize.
+      const replacement = target.cloneNode(false);
+      replacement.src = nextSrc;
+      target.replaceWith(replacement);
 
     }
 

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -1,8 +1,8 @@
 use crate::ServerState;
 use anyhow::{bail, Result};
 use log::{debug, error};
-use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
-use std::{sync::Arc, time::Duration};
+use notify::{event::AccessKind, Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use std::{path::Path, sync::Arc, time::Duration};
 use tokio::{process::Command, time::Instant};
 
 pub async fn setup_watching_typst(state: Arc<ServerState>) -> Result<RecommendedWatcher> {
@@ -36,16 +36,22 @@ pub async fn setup_watching_typst(state: Arc<ServerState>) -> Result<Recommended
     } else {
         state.args.filename.clone()
     };
+    let watched_file = watchpath.canonicalize().unwrap_or(watchpath.clone());
+    let watched_name = watched_file.file_name().map(|x| x.to_os_string());
+    let watched_parent = watched_file
+        .parent()
+        .and_then(|p| p.canonicalize().ok())
+        .or_else(|| watchpath.parent().map(|p| p.to_path_buf()));
 
     let mut watcher = notify::recommended_watcher(move |e: Result<Event, _>| match e {
-        Ok(e) if matches!(e.kind, EventKind::Modify(_)) => {
-            let ending = if state.args.no_recompile {
-                &state.args.filename
-            } else {
-                &state.scratch
-            };
+        Ok(e) => {
+            debug!("Watch event: kind={:?}, paths={:?}", e.kind, e.paths);
 
-            if e.paths.iter().any(|p| p.ends_with(ending))
+            let relevant_kind = matches!(e.kind, EventKind::Modify(_) | EventKind::Create(_) | EventKind::Any)
+                && !matches!(e.kind, EventKind::Access(AccessKind::Read));
+
+            if relevant_kind
+                && e.paths.iter().any(|p| matches_watched_file(p, watched_name.as_deref(), watched_parent.as_deref()))
                 && last_update.elapsed() > Duration::from_millis(100)
             {
                 debug!("File has changed, notifying waiters");
@@ -55,9 +61,33 @@ pub async fn setup_watching_typst(state: Arc<ServerState>) -> Result<Recommended
             }
         }
         Err(err) => error!("{err}"),
-        _ => {}
     })?;
     watcher.watch(watchpath.parent().unwrap(), RecursiveMode::NonRecursive)?;
 
     Ok(watcher)
+}
+
+fn matches_watched_file(
+    path: &Path,
+    watched_name: Option<&std::ffi::OsStr>,
+    watched_parent: Option<&Path>,
+) -> bool {
+    let Some(watched_name) = watched_name else {
+        return false;
+    };
+
+    if path.file_name() != Some(watched_name) {
+        return false;
+    }
+
+    let Some(watched_parent) = watched_parent else {
+        return true;
+    };
+
+    let event_parent = path.parent().unwrap_or(path);
+    let event_parent = event_parent
+        .canonicalize()
+        .unwrap_or_else(|_| event_parent.to_path_buf());
+
+    event_parent == watched_parent
 }


### PR DESCRIPTION
Summary
This PR fixes a macOS-specific hot reload issue where Typst recompilation succeeds, but the browser preview does not refresh.

The root cause was in the file watcher path matching: on macOS, file events for the temp PDF can be reported with canonicalized paths (for example /private/var/...) while the app tracks the file using /var/.... This caused the watcher to miss valid updates, so no websocket refresh message was sent to the browser.

This PR also improves the browser-side refresh behavior for Safari/WebKit by forcing a full iframe reload of the embedded PDF.

What Changed

Fixed watcher path matching in [watcher.rs](app://-/index.html#)
Canonicalize the watched file/parent path before matching
Match events by filename + canonicalized parent directory (instead of strict ends_with on absolute path)
Accept additional relevant notify event kinds (Create, Any) in addition to Modify
Add debug logging for watcher events to make platform-specific file event behavior easier to diagnose
Harden browser refresh logic in [index.html](app://-/index.html#)
Add a cache-busting query parameter to the PDF URL on refresh
Replace the PDF iframe element on refresh to force Safari/WebKit to reinitialize the embedded PDF viewer
Why This Fix Works

macOS can report temporary file events with path variants (/var vs /private/var), which broke the previous path comparison.
Once the watcher correctly recognizes the updated PDF, the websocket refresh message is delivered.
Safari/WebKit may still show a cached embedded PDF even when [iframe.src](app://-/index.html#) is reassigned, so replacing the iframe ensures the preview updates visibly.