### PR TITLE
Bugfix/macos hot reload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 
 *.typ
 *.pdf
+
+.idea

--- a/src/index.html
+++ b/src/index.html
@@ -3,49 +3,259 @@
 
 <head>
   <script>
-    let connected = false;
+    const PDF_PATH = "/target.pdf";
+    const STORAGE_KEY = "typst-live:pdf-view-state:v1";
+    const POLL_INTERVAL_MS = 300;
 
-    document.addEventListener("DOMContentLoaded", function () {
-      document.getElementById("target").focus();
-    });
+    let ws = null;
+    let reconnectDelayMs = 500;
+    let reconnectTimer = null;
+    let viewerPollTimer = null;
+    let lastKnownViewerState = { hash: "", page: null };
 
-    let path = new URL(location);
-    path.protocol = location.protocol == "http:" ? "ws:" : "wss:";
-    path.pathname = "/listen";
+    function getTarget() {
+      return document.getElementById("target");
+    }
 
-    function onMessage(event) {
-      if (event.data != "refresh") {
-        console.error(`[typst-live] Received unknown message from websocket: ${event.data}`)
-        return;
+    function normalizeHash(hash) {
+      if (!hash) return "";
+      return hash.startsWith("#") ? hash : `#${hash}`;
+    }
+
+    function parsePageFromHash(hash) {
+      const normalized = normalizeHash(hash);
+      if (!normalized) return null;
+
+      const page = Number.parseInt(new URLSearchParams(normalized.slice(1)).get("page") || "", 10);
+      return Number.isFinite(page) && page > 0 ? page : null;
+    }
+
+    function sanitizeViewerState(state) {
+      if (!state || typeof state !== "object") {
+        return { hash: "", page: null };
       }
 
-      console.log("[typst-live] Got refresh message, updating pdf");
-      const target = document.getElementById("target");
-      const url = new URL(target.src, location.href);
-      url.searchParams.set("t", Date.now().toString());
-      const nextSrc = url.toString();
+      const hash = normalizeHash(typeof state.hash === "string" ? state.hash : "");
+      const parsedPage = parsePageFromHash(hash);
+      const explicitPage = Number.isFinite(state.page) && state.page > 0 ? Math.trunc(state.page) : null;
+
+      return {
+        hash,
+        page: parsedPage ?? explicitPage,
+      };
+    }
+
+    function readStoredViewerState() {
+      const candidates = [];
+
+      if (history.state && typeof history.state === "object" && history.state.typstLivePdfViewerState) {
+        candidates.push(history.state.typstLivePdfViewerState);
+      }
+
+      try {
+        const raw = sessionStorage.getItem(STORAGE_KEY);
+        if (raw) {
+          candidates.push(JSON.parse(raw));
+        }
+      } catch (err) {
+        console.warn("[typst-live] Failed to read sessionStorage state", err);
+      }
+
+      for (const candidate of candidates) {
+        const state = sanitizeViewerState(candidate);
+        if (state.hash || state.page) {
+          return state;
+        }
+      }
+
+      return { hash: "", page: null };
+    }
+
+    function persistViewerState(state) {
+      const nextState = sanitizeViewerState(state || captureViewerState());
+      lastKnownViewerState = nextState;
+
+      try {
+        sessionStorage.setItem(STORAGE_KEY, JSON.stringify(nextState));
+      } catch (err) {
+        // sessionStorage can be disabled by browser privacy settings.
+      }
+
+      const nextHistoryState = Object.assign({}, history.state || {}, {
+        typstLivePdfViewerState: nextState,
+      });
+      history.replaceState(nextHistoryState, "");
+
+      return nextState;
+    }
+
+    function readPdfHashFromIframe(target) {
+      if (!target) return "";
+
+      try {
+        const hash = target.contentWindow && target.contentWindow.location && target.contentWindow.location.hash;
+        if (typeof hash === "string" && hash.length > 0) {
+          return normalizeHash(hash);
+        }
+      } catch (_) {
+        // Native PDF viewers are often not script-readable from the parent context.
+      }
+
+      const attrSrc = target.getAttribute("src");
+      if (attrSrc) {
+        try {
+          return normalizeHash(new URL(attrSrc, location.href).hash);
+        } catch (_) {
+          // Ignore invalid/intermediate values.
+        }
+      }
+
+      if (target.src) {
+        try {
+          return normalizeHash(new URL(target.src, location.href).hash);
+        } catch (_) {
+          // Ignore invalid/intermediate values.
+        }
+      }
+
+      return "";
+    }
+
+    function captureViewerState() {
+      const target = getTarget();
+      const hash = readPdfHashFromIframe(target) || lastKnownViewerState.hash;
+      const page = parsePageFromHash(hash) || lastKnownViewerState.page || null;
+      const state = { hash, page };
+      lastKnownViewerState = state;
+      return state;
+    }
+
+    function buildPdfUrl(options = {}) {
+      const { bustCache = false, viewerState = lastKnownViewerState } = options;
+      const url = new URL(PDF_PATH, location.href);
+
+      if (bustCache) {
+        url.searchParams.set("t", Date.now().toString());
+      }
+
+      const state = sanitizeViewerState(viewerState);
+      if (state.hash) {
+        url.hash = state.hash.slice(1);
+      } else if (state.page) {
+        url.hash = `page=${state.page}`;
+      }
+
+      return url.toString();
+    }
+
+    function wireTarget(target) {
+      target.addEventListener("load", function () {
+        // Persist after each iframe load so top-level page reloads can restore the last view.
+        persistViewerState(captureViewerState());
+      });
+    }
+
+    function replaceIframeWithUrl(nextSrc) {
+      const target = getTarget();
+      if (!target) return;
 
       // Safari/WebKit can keep showing a cached PDF even when the iframe src changes.
       // Replacing the iframe forces the embedded PDF viewer to fully reinitialize.
       const replacement = target.cloneNode(false);
+      wireTarget(replacement);
       replacement.src = nextSrc;
       target.replaceWith(replacement);
-
     }
 
-    function onOpen(event) {
+    function refreshPdf() {
+      const viewerState = persistViewerState(captureViewerState());
+      const nextSrc = buildPdfUrl({ bustCache: true, viewerState });
+      replaceIframeWithUrl(nextSrc);
+    }
+
+    function onMessage(event) {
+      if (event.data !== "refresh") {
+        console.error(`[typst-live] Received unknown message from websocket: ${event.data}`);
+        return;
+      }
+
+      console.log("[typst-live] Got refresh message, updating pdf");
+      refreshPdf();
+    }
+
+    function onOpen() {
+      reconnectDelayMs = 500;
       console.log("[typst-live] Connected to the listen endpoint");
     }
 
-    function onClose(event) {
-      console.log("[typst-live] Connection closed");
+    function scheduleReconnect() {
+      if (reconnectTimer !== null) {
+        return;
+      }
+
+      reconnectTimer = window.setTimeout(function () {
+        reconnectTimer = null;
+        connectWebSocket();
+      }, reconnectDelayMs);
+
+      reconnectDelayMs = Math.min(reconnectDelayMs * 2, 5000);
     }
 
-    const ws = new WebSocket(path)
+    function onClose() {
+      console.log("[typst-live] Connection closed");
+      scheduleReconnect();
+    }
 
-    ws.addEventListener("open", onOpen)
-    ws.addEventListener("close", onClose)
-    ws.addEventListener("message", onMessage)
+    function connectWebSocket() {
+      const path = new URL(location.href);
+      path.protocol = location.protocol === "http:" ? "ws:" : "wss:";
+      path.pathname = "/listen";
+      path.search = "";
+      path.hash = "";
+
+      ws = new WebSocket(path);
+      ws.addEventListener("open", onOpen);
+      ws.addEventListener("close", onClose);
+      ws.addEventListener("message", onMessage);
+      ws.addEventListener("error", function () {
+        // Let the close event drive reconnect behavior.
+      });
+    }
+
+    function startViewerPolling() {
+      if (viewerPollTimer !== null) {
+        window.clearInterval(viewerPollTimer);
+      }
+
+      viewerPollTimer = window.setInterval(function () {
+        captureViewerState();
+      }, POLL_INTERVAL_MS);
+    }
+
+    function persistOnLifecycleBoundary() {
+      persistViewerState(captureViewerState());
+    }
+
+    document.addEventListener("DOMContentLoaded", function () {
+      lastKnownViewerState = readStoredViewerState();
+
+      const target = getTarget();
+      wireTarget(target);
+      target.src = buildPdfUrl({ bustCache: true, viewerState: lastKnownViewerState });
+      target.focus();
+
+      startViewerPolling();
+
+      document.addEventListener("visibilitychange", function () {
+        if (document.visibilityState === "hidden") {
+          persistOnLifecycleBoundary();
+        }
+      });
+      window.addEventListener("pagehide", persistOnLifecycleBoundary);
+      window.addEventListener("beforeunload", persistOnLifecycleBoundary);
+
+      connectWebSocket();
+    });
   </script>
 
   <style>
@@ -63,7 +273,7 @@
 </head>
 
 <body>
-  <iframe id="target" src="/target.pdf" type="application/pdf" width="100%" height="100%" />
+  <iframe id="target" type="application/pdf" width="100%" height="100%"></iframe>
 </body>
 
 </html>

--- a/src/index.html
+++ b/src/index.html
@@ -20,7 +20,16 @@
       }
 
       console.log("[typst-live] Got refresh message, updating pdf");
-      document.getElementById("target").src += ""
+      const target = document.getElementById("target");
+      const url = new URL(target.src, location.href);
+      url.searchParams.set("t", Date.now().toString());
+      const nextSrc = url.toString();
+
+      // Safari/WebKit can keep showing a cached PDF even when the iframe src changes.
+      // Replacing the iframe forces the embedded PDF viewer to fully reinitialize.
+      const replacement = target.cloneNode(false);
+      replacement.src = nextSrc;
+      target.replaceWith(replacement);
 
     }
 

--- a/src/index.html
+++ b/src/index.html
@@ -41,7 +41,7 @@
 
       return {
         hash,
-        page: parsedPage ?? explicitPage,
+        page: parsedPage !== null ? parsedPage : explicitPage,
       };
     }
 

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -1,8 +1,8 @@
 use crate::ServerState;
 use anyhow::{bail, Result};
 use log::{debug, error};
-use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
-use std::{sync::Arc, time::Duration};
+use notify::{event::AccessKind, Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use std::{path::Path, sync::Arc, time::Duration};
 use tokio::{process::Command, time::Instant};
 
 pub async fn setup_watching_typst(state: Arc<ServerState>) -> Result<RecommendedWatcher> {
@@ -36,16 +36,22 @@ pub async fn setup_watching_typst(state: Arc<ServerState>) -> Result<Recommended
     } else {
         state.args.filename.clone()
     };
+    let watched_file = watchpath.canonicalize().unwrap_or(watchpath.clone());
+    let watched_name = watched_file.file_name().map(|x| x.to_os_string());
+    let watched_parent = watched_file
+        .parent()
+        .and_then(|p| p.canonicalize().ok())
+        .or_else(|| watchpath.parent().map(|p| p.to_path_buf()));
 
     let mut watcher = notify::recommended_watcher(move |e: Result<Event, _>| match e {
-        Ok(e) if matches!(e.kind, EventKind::Modify(_)) => {
-            let ending = if state.args.no_recompile {
-                &state.args.filename
-            } else {
-                &state.scratch
-            };
+        Ok(e) => {
+            debug!("Watch event: kind={:?}, paths={:?}", e.kind, e.paths);
 
-            if e.paths.iter().any(|p| p.ends_with(ending))
+            let relevant_kind = matches!(e.kind, EventKind::Modify(_) | EventKind::Create(_) | EventKind::Any)
+                && !matches!(e.kind, EventKind::Access(AccessKind::Read));
+
+            if relevant_kind
+                && e.paths.iter().any(|p| matches_watched_file(p, watched_name.as_deref(), watched_parent.as_deref()))
                 && last_update.elapsed() > Duration::from_millis(100)
             {
                 debug!("File has changed, notifying waiters");
@@ -55,9 +61,33 @@ pub async fn setup_watching_typst(state: Arc<ServerState>) -> Result<Recommended
             }
         }
         Err(err) => error!("{err}"),
-        _ => {}
     })?;
     watcher.watch(watchpath.parent().unwrap(), RecursiveMode::NonRecursive)?;
 
     Ok(watcher)
+}
+
+fn matches_watched_file(
+    path: &Path,
+    watched_name: Option<&std::ffi::OsStr>,
+    watched_parent: Option<&Path>,
+) -> bool {
+    let Some(watched_name) = watched_name else {
+        return false;
+    };
+
+    if path.file_name() != Some(watched_name) {
+        return false;
+    }
+
+    let Some(watched_parent) = watched_parent else {
+        return true;
+    };
+
+    let event_parent = path.parent().unwrap_or(path);
+    let event_parent = event_parent
+        .canonicalize()
+        .unwrap_or_else(|_| event_parent.to_path_buf());
+
+    event_parent == watched_parent
 }


### PR DESCRIPTION
Summary
This PR fixes a macOS-specific hot reload issue where Typst recompilation succeeds, but the browser preview does not refresh.

The root cause was in the file watcher path matching: on macOS, file events for the temp PDF can be reported with canonicalized paths (for example /private/var/...) while the app tracks the file using /var/.... This caused the watcher to miss valid updates, so no websocket refresh message was sent to the browser.

This PR also improves the browser-side refresh behavior for Safari/WebKit by forcing a full iframe reload of the embedded PDF.

What Changed

Fixed watcher path matching in [watcher.rs](app://-/index.html#)
Canonicalize the watched file/parent path before matching
Match events by filename + canonicalized parent directory (instead of strict ends_with on absolute path)
Accept additional relevant notify event kinds (Create, Any) in addition to Modify
Add debug logging for watcher events to make platform-specific file event behavior easier to diagnose
Harden browser refresh logic in [index.html](app://-/index.html#)
Add a cache-busting query parameter to the PDF URL on refresh
Replace the PDF iframe element on refresh to force Safari/WebKit to reinitialize the embedded PDF viewer
Why This Fix Works

macOS can report temporary file events with path variants (/var vs /private/var), which broke the previous path comparison.
Once the watcher correctly recognizes the updated PDF, the websocket refresh message is delivered.
Safari/WebKit may still show a cached embedded PDF even when [iframe.src](app://-/index.html#) is reassigned, so replacing the iframe ensures the preview updates visibly.